### PR TITLE
Feature/sink multiple input schemas

### DIFF
--- a/database-commons/src/main/java/co/cask/db/batch/sink/AbstractDBSink.java
+++ b/database-commons/src/main/java/co/cask/db/batch/sink/AbstractDBSink.java
@@ -137,7 +137,6 @@ public abstract class AbstractDBSink extends ReferenceBatchSink<StructuredRecord
    * and insert during query generation. Override this method if you need to escape column names
    * for databases with case-sensitive identifiers
    *
-   * @param fields input schema fields
    */
   protected void setColumnsInfo(List<Schema.Field> fields) {
     columns = fields.stream()
@@ -261,7 +260,8 @@ public abstract class AbstractDBSink extends ReferenceBatchSink<StructuredRecord
     try (Connection connection = DriverManager.getConnection(connectionString, dbSinkConfig.getConnectionArguments());
          ResultSet tables = connection.getMetaData().getTables(null, null, tableName, null)) {
 
-      Preconditions.checkArgument(tables.next(), "Table %s does not exist. " +
+      Preconditions.checkArgument(tables.next(),
+                                  "Table %s does not exist. " +
                                     "Please check that the 'tableName' property " +
                                     "has been set correctly, and that the connection string %s " +
                                     "points to a valid database.",
@@ -311,8 +311,9 @@ public abstract class AbstractDBSink extends ReferenceBatchSink<StructuredRecord
       }
     }
 
-    Preconditions.checkArgument(invalidFields.isEmpty(), "Couldn't find matching database column(s) " +
-      "for input field(s) %s.", String.join(",", invalidFields));
+    Preconditions.checkArgument(invalidFields.isEmpty(),
+                                "Couldn't find matching database column(s) for input field(s) %s.",
+                                String.join(",", invalidFields));
   }
 
   private void emitLineage(BatchSinkContext context, List<Schema.Field> fields) {

--- a/mysql-plugin/src/main/java/co/cask/mysql/MysqlAction.java
+++ b/mysql-plugin/src/main/java/co/cask/mysql/MysqlAction.java
@@ -25,6 +25,7 @@ import co.cask.db.batch.config.DBSpecificQueryConfig;
 import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * Action that runs MySQL command.
@@ -48,6 +49,7 @@ public class MysqlAction extends AbstractDBAction {
 
     @Name(MysqlConstants.AUTO_RECONNECT)
     @Description("Should the driver try to re-establish stale and/or dead connections")
+    @Nullable
     public Boolean autoReconnect;
 
     @Override
@@ -59,7 +61,9 @@ public class MysqlAction extends AbstractDBAction {
     public Map<String, String> getDBSpecificArguments() {
       ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
 
-      builder.put(MysqlConstants.AUTO_RECONNECT, String.valueOf(autoReconnect));
+      if (autoReconnect != null) {
+        builder.put(MysqlConstants.AUTO_RECONNECT, String.valueOf(autoReconnect));
+      }
       builder.put(MysqlConstants.ALLOW_MULTIPLE_QUERIES, String.valueOf(true));
 
       return builder.build();

--- a/mysql-plugin/src/main/java/co/cask/mysql/MysqlPostAction.java
+++ b/mysql-plugin/src/main/java/co/cask/mysql/MysqlPostAction.java
@@ -25,6 +25,7 @@ import co.cask.db.batch.config.DBSpecificQueryActionConfig;
 import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * Represents MySQL post action.
@@ -48,6 +49,7 @@ public class MysqlPostAction extends AbstractQueryAction {
 
     @Name(MysqlConstants.AUTO_RECONNECT)
     @Description("Should the driver try to re-establish stale and/or dead connections")
+    @Nullable
     public Boolean autoReconnect;
 
     @Override
@@ -59,7 +61,9 @@ public class MysqlPostAction extends AbstractQueryAction {
     public Map<String, String> getDBSpecificArguments() {
       ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
 
-      builder.put(MysqlConstants.AUTO_RECONNECT, String.valueOf(autoReconnect));
+      if (autoReconnect != null) {
+        builder.put(MysqlConstants.AUTO_RECONNECT, String.valueOf(autoReconnect));
+      }
       builder.put(MysqlConstants.ALLOW_MULTIPLE_QUERIES, String.valueOf(true));
 
       return builder.build();

--- a/mysql-plugin/src/main/java/co/cask/mysql/MysqlSink.java
+++ b/mysql-plugin/src/main/java/co/cask/mysql/MysqlSink.java
@@ -25,6 +25,7 @@ import co.cask.db.batch.sink.AbstractDBSink;
 import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
+import javax.annotation.Nullable;
 
 
 /**
@@ -48,6 +49,7 @@ public class MysqlSink extends AbstractDBSink {
   public static class MysqlSinkConfig extends DBSpecificSinkConfig {
     @Name(MysqlConstants.AUTO_RECONNECT)
     @Description("Should the driver try to re-establish stale and/or dead connections")
+    @Nullable
     public Boolean autoReconnect;
 
     @Override
@@ -57,7 +59,11 @@ public class MysqlSink extends AbstractDBSink {
 
     @Override
     public Map<String, String> getDBSpecificArguments() {
-      return ImmutableMap.of(MysqlConstants.AUTO_RECONNECT, String.valueOf(autoReconnect));
+      if (autoReconnect != null) {
+        return ImmutableMap.of(MysqlConstants.AUTO_RECONNECT, String.valueOf(autoReconnect));
+      } else {
+        return ImmutableMap.of();
+      }
     }
   }
 }

--- a/mysql-plugin/src/main/java/co/cask/mysql/MysqlSource.java
+++ b/mysql-plugin/src/main/java/co/cask/mysql/MysqlSource.java
@@ -24,6 +24,7 @@ import co.cask.db.batch.source.AbstractDBSource;
 import com.google.common.collect.ImmutableMap;
 
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * Batch source to read from MySQL.
@@ -53,6 +54,7 @@ public class MysqlSource extends AbstractDBSource {
 
     @Name(MysqlConstants.AUTO_RECONNECT)
     @Description("Should the driver try to re-establish stale and/or dead connections")
+    @Nullable
     public Boolean autoReconnect;
 
     @Override
@@ -62,7 +64,11 @@ public class MysqlSource extends AbstractDBSource {
 
     @Override
     public Map<String, String> getDBSpecificArguments() {
-      return ImmutableMap.of(MysqlConstants.AUTO_RECONNECT, String.valueOf(autoReconnect));
+      if (autoReconnect != null) {
+        return ImmutableMap.of(MysqlConstants.AUTO_RECONNECT, String.valueOf(autoReconnect));
+      } else {
+        return ImmutableMap.of();
+      }
     }
   }
 }

--- a/postgresql-plugin/src/main/java/co/cask/postgres/PostgresSink.java
+++ b/postgresql-plugin/src/main/java/co/cask/postgres/PostgresSink.java
@@ -19,12 +19,17 @@ package co.cask.postgres;
 import co.cask.cdap.api.annotation.Description;
 import co.cask.cdap.api.annotation.Name;
 import co.cask.cdap.api.annotation.Plugin;
+import co.cask.cdap.api.data.schema.Schema;
 import co.cask.cdap.etl.api.batch.BatchSink;
 import co.cask.db.batch.config.DBSpecificSinkConfig;
 import co.cask.db.batch.sink.AbstractDBSink;
 import com.google.common.collect.ImmutableMap;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.StringJoiner;
 import javax.annotation.Nullable;
 
 
@@ -41,6 +46,20 @@ public class PostgresSink extends AbstractDBSink {
   public PostgresSink(PostgresSinkConfig postgresSinkConfig) {
     super(postgresSinkConfig);
     this.postgresSinkConfig = postgresSinkConfig;
+  }
+
+  @Override
+  protected void setColumnsInfo(List<Schema.Field> fields) {
+    List<String> columnsList = new ArrayList<>();
+    StringJoiner columnsJoiner = new StringJoiner(",");
+
+    for (Schema.Field field : fields) {
+      columnsList.add(field.getName());
+      columnsJoiner.add("\"" + field.getName() + "\"");
+    }
+
+    super.columns = Collections.unmodifiableList(columnsList);
+    super.dbColumns = columnsJoiner.toString();
   }
 
   /**


### PR DESCRIPTION
- Improve multiple input schemas handling in DB sink.
- Make MySQL autoReconnect property optional with default value.
- Add hook to support databases with case-sensitive identifiers.